### PR TITLE
bcfs: canonicalize paths

### DIFF
--- a/bcfs/src/tests.rs
+++ b/bcfs/src/tests.rs
@@ -105,8 +105,12 @@ testcase!(
     fn open_close(ptx: &mut dyn PendingTransaction) -> u16 {
         let mut bcfs = BCFS::new(ptx, CHAIN_NAME);
         let mut abspath = good_home();
+        abspath.push(".");
+        abspath.push(".");
         abspath.push("somefile");
-        let relpath = PathBuf::from("somefile");
+        abspath.push("..");
+        abspath.push("somefile");
+        let relpath = PathBuf::from("./././././somefile/../somefile/.");
 
         let abs_fd = bcfs
             .open(ptx, None, &abspath, OpenFlags::CREATE, FdFlags::empty())


### PR DESCRIPTION
Turns out you can implement [these two crates](https://crates.io/search?q=dedot) in 22 lines of code.