### PR TITLE
Deserialize unit variants from nullary sequences

### DIFF
--- a/mantle-build/Cargo.toml
+++ b/mantle-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mantle-build"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Oasis Labs <feedback@oasislabs.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/tests/idl-gen/res/DefaultFnService.json
+++ b/tests/idl-gen/res/DefaultFnService.json
@@ -1,9 +1,0 @@
-{
-  "name": "DefaultFnService",
-  "namespace": "default_fn",
-  "constructor": {
-    "inputs": []
-  },
-  "has_default_function": true,
-  "mantle_build_version": "0.2.2"
-}

--- a/tests/idl-gen/res/NonDefaultFnService.json
+++ b/tests/idl-gen/res/NonDefaultFnService.json
@@ -12,5 +12,5 @@
       "mutability": "immutable"
     }
   ],
-  "mantle_build_version": "0.2.2"
+  "mantle_build_version": "0.2.3"
 }

--- a/tests/idl-gen/res/TestService.json
+++ b/tests/idl-gen/res/TestService.json
@@ -270,5 +270,5 @@
       }
     }
   ],
-  "mantle_build_version": "0.2.2"
+  "mantle_build_version": "0.2.3"
 }

--- a/tests/xcc-a/res/ServiceA.json
+++ b/tests/xcc-a/res/ServiceA.json
@@ -45,5 +45,5 @@
       }
     }
   ],
-  "mantle_build_version": "0.2.2"
+  "mantle_build_version": "0.2.3"
 }


### PR DESCRIPTION
This _should_ allow `[]` to be deserialized as the `PayloadVariant()` generated for `my_func(&self, ctx: &Context)` or `new(ctx: &Context)`,